### PR TITLE
Update MK8 Cluster Fuel Resistor Requirements

### DIFF
--- a/ford-fiesta-mk8-petrol/xConnect_link/README.md
+++ b/ford-fiesta-mk8-petrol/xConnect_link/README.md
@@ -14,4 +14,13 @@ CANH - PIN 12
 
 CANL - PIN 13
 
-Connect a 180 ohm resistor between fuel lvl, and fuel lvl return to get full fuel
+
+## Fuel
+
+Fuel level is determined by the resistance between fuel lvl and fuel lvl return pins.
+
+Connect a 10 ohm resistor to display full fuel (this is a four band resistor with the following properties: Band #1 Brown, Band #2 Black, Multiplier #3 Black, Tolerance #4 Gold)
+
+An 180 ohm resistor will display empty fuel (default if no resistor is connected).
+
+Values in between 10 <-> 180 will display differing fuel levels.


### PR DESCRIPTION
The current instructions request a 180ohm resistor connection to display full fuel. However an 180ohm resistor displays empty on the cluster.

This is an update to the Focus MK8 Cluster readme to clarify that a 10ohm resistor is required for full fuel. This was identified through digging through the xconnect discord and functional testing